### PR TITLE
feat: customize workout boards and clarify account selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-07
+
+A more customizable workout board with clearer account selection.
+
+- Choose whether to show exercise removal, set type, RPE, and the Private workout control through the visual editor or card configuration.
+- Set the privacy default for new workouts. Saved sessions keep their privacy when opened on another card.
+- Optionally collapse completed sets into summaries that can be expanded for editing or unchecked to undo completion.
+- Show Hevy account names in the picker and workout header, with integration names as a fallback and custom label.
+- Optionally show total workouts, last-7-day activity, and streak for the selected account.
+- Review the destination account and workout privacy in the finish confirmation.
+
+Existing cards keep their display defaults. After updating, change the dashboard resource URL to `/hevy/hevy-workout-card.js?version=1.5.0` and reload the browser. See the [board settings and shared-tablet guide](https://github.com/DisplacedForest/ha-hevy-tracker#customize-your-workout-board).
+
 ## [1.4.0] - 2026-09-06
 
 Log workouts from a Home Assistant dashboard. Pick a routine, adjust your sets, and check them off as you go. Your draft stays saved through refreshes and restarts.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,11 +67,15 @@ Python tests live in `tests/`. The bundled frontend has browser behavior tests r
 
 ## Testing the live workout card
 
-Copy the integration into a local Home Assistant instance and restart it. Add `/hevy/hevy-workout-card.js?version=1.4.0` as a JavaScript Module resource, then add a `custom:hevy-workout-card` dashboard card.
+Copy the integration into a local Home Assistant instance and restart it. Add `/hevy/hevy-workout-card.js?version=1.5.0` as a JavaScript Module resource, then add a `custom:hevy-workout-card` dashboard card.
 
 Check routine selection, exercise search, set editing, completion checkboxes, finish confirmation, and canceling a session. Verify that refresh, reconnect, and a Home Assistant restart restore the saved session. Confirm that only completed sets appear in the submitted workout, and that changing the integration units does not reinterpret an existing session.
 
 Exercise the uncertain submission state with a controlled API timeout. Check that it requires checking Hevy before retrying or clearing the session. Use fixtures for repeatable error and recovery checks. Record real writes separately, since a fixture response cannot prove that Hevy accepted a workout.
+
+For the standalone browser fixture, serve the repository with a local HTTP server and open `tests/frontend/preview.html`. Add `?customized=1` to exercise hidden controls, private defaults, completed-set summaries, and account stats. The fixture has two accounts with separate drafts and never sends data to Hevy. It complements the local Home Assistant checks.
+
+For 1.5, verify each visual editor switch and the same options in YAML. Check that hidden set type and RPE values survive edits and submission, and that a hidden privacy control uses the chosen default only for new sessions. Expand a completed set, correct it, collapse it again, and undo completion. Test account switching with pending edits and confirm the selected name, routines, draft, stats, and finish destination remain consistent. Repeat at tablet and phone widths.
 
 ## Testing the calendar card
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ The bundled live workout card and native calendar card work alongside your exist
 
 ### Live workout card
 
-The card is included with the integration and requires Home Assistant 2024.7 or later. After installing or updating to 1.4 and restarting Home Assistant:
+The card is included with the integration and requires Home Assistant 2024.7 or later. After installing or updating to 1.5 and restarting Home Assistant:
 
 1. Enable **Advanced mode** in your Home Assistant profile if Resources is hidden.
-2. Open **Settings → Dashboards → Resources** and add `/hevy/hevy-workout-card.js?version=1.4.0` with resource type **JavaScript Module**.
+2. Open **Settings → Dashboards → Resources** and add `/hevy/hevy-workout-card.js?version=1.5.0` with resource type **JavaScript Module**.
 3. Add a manual card to your dashboard:
 
 ```yaml
@@ -108,6 +108,47 @@ Home Assistant saves one active session per Hevy integration entry. Refreshing t
 The next-routine suggestion uses the integration's existing rotation data. Hevy's public workout creation API does not link new logs to a routine, so logging from the card does not automatically advance that rotation.
 
 The card requires a connection to Home Assistant to save changes and does not accept offline edits. If a network interruption leaves the result of a finish request uncertain, check Hevy for the workout before choosing to retry or clear the session. Retrying a workout that already reached Hevy can create a duplicate.
+
+### Customize your workout board
+
+Open the card's visual editor to choose which controls appear. Every setting below is optional. Existing cards keep their current defaults.
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| `show_remove_exercise` | `true` | Shows the Remove button next to each exercise. Set removal stays available. |
+| `show_set_type` | `true` | Shows the set type dropdown. Hiding it preserves the routine or saved set type. |
+| `show_rpe` | `true` | Shows the RPE dropdown. Hiding it preserves any saved RPE. |
+| `show_private_workout` | `true` | Shows the Private workout checkbox. |
+| `default_private_workout` | `false` | Makes new sessions public or private. Applies once when starting a workout. |
+| `collapse_completed_sets` | `false` | Collapses checked sets into a measurement summary. Choose Show details to edit, or uncheck a set to undo completion. |
+| `show_account_stats` | `false` | Shows total workouts, the last 7 days' workout count, and streak for the selected account. |
+
+For a compact board with private workouts and account stats:
+
+```yaml
+type: custom:hevy-workout-card
+show_remove_exercise: false
+show_set_type: false
+show_rpe: false
+show_private_workout: false
+default_private_workout: true
+collapse_completed_sets: true
+show_account_stats: true
+```
+
+Display settings belong to each card. Saved sessions keep their privacy, set types, RPE, and completed sets when opened from another card with different display settings. Hiding a control does not erase its value. The finish confirmation always shows the account and actual workout privacy before sending.
+
+### Shared tablets and multiple accounts
+
+Add the integration once per person's Hevy account, using that person's API key. Each account needs Hevy API access, currently provided with Hevy Pro. Each entry has its own routines, stats, and saved workout. On a shared tablet, use **Who is working out?** to switch accounts. A separate Home Assistant login for every person is optional.
+
+The picker uses the Hevy display name when available. Rename the integration entry in Home Assistant to give it your own label, especially when two accounts share a name. If the profile lookup is unavailable, the entry name still works. Profile names load when the integration starts; reload it to fetch a changed Hevy name. API keys stay in the integration and never belong in card configuration.
+
+Set `config_entry_id` to choose the account a card opens on. With multiple entries, the picker remains available. Switching accounts saves pending edits first; invalid or unsaved edits must be resolved before switching. Account selection belongs to that card, so another screen can keep working with a different account.
+
+Enable `show_account_stats` for stats that follow the picker. These use the integration's existing polling data and refresh after a confirmed workout submission. Unavailable data is labeled instead of displayed as zero. Standalone stats cards in the examples below still need the entity IDs for the intended account, including any IDs inside their templates. They do not follow this card's account picker.
+
+Account selection is for choosing the workout destination. It does not restrict which Home Assistant users can access an account. The Private workout setting controls the workout's visibility in Hevy. Local profiles cannot divide one Hevy account into separate people's histories.
 
 ### Dashboard examples
 

--- a/custom_components/hevy/__init__.py
+++ b/custom_components/hevy/__init__.py
@@ -74,6 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch exercise templates and routines before first data refresh
     await coordinator.fetch_exercise_templates()
     await coordinator.fetch_routines()
+    await coordinator.fetch_account_name()
 
     # Fetch initial data
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/hevy/api.py
+++ b/custom_components/hevy/api.py
@@ -138,6 +138,9 @@ class HevyApiClient:
     async def create_workout(self, workout: dict[str, Any]) -> dict[str, Any]:
         return await self._request("POST", "/workouts", json=workout)
 
+    async def get_user_info(self) -> dict[str, Any]:
+        return await self._request("GET", "/user/info")
+
     async def get_workout_events(
         self, page: int = 1, page_size: int = 10
     ) -> dict[str, Any]:

--- a/custom_components/hevy/coordinator.py
+++ b/custom_components/hevy/coordinator.py
@@ -61,6 +61,18 @@ class HevyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._exercise_templates: dict[str, dict] = {}  # Cache templates by ID
         self._routines: list[dict[str, Any]] = []
         self.workout_session: WorkoutSession | None = None
+        self.account_name: str | None = None
+
+    async def fetch_account_name(self) -> None:
+        try:
+            response = await self.client.get_user_info()
+        except (HevyApiError, ValueError):
+            _LOGGER.debug("Hevy account name is unavailable")
+            return
+        data = response.get("data") if isinstance(response, dict) else None
+        name = data.get("name") if isinstance(data, dict) else None
+        if isinstance(name, str) and name.strip():
+            self.account_name = name.strip()[:200]
 
     @property
     def exercise_templates(self) -> dict[str, dict]:

--- a/custom_components/hevy/frontend/hevy-workout-card.js
+++ b/custom_components/hevy/frontend/hevy-workout-card.js
@@ -1,6 +1,15 @@
 const escapeHTML = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char]);
 const copy = (value) => JSON.parse(JSON.stringify(value));
 const setTypes = ["normal", "warmup", "failure", "dropset"];
+const boardOptions = {
+  show_remove_exercise: [true, "Show exercise Remove button"],
+  show_set_type: [true, "Show set type"],
+  show_rpe: [true, "Show RPE"],
+  show_private_workout: [true, "Show Private workout control"],
+  default_private_workout: [false, "Make new workouts private by default"],
+  collapse_completed_sets: [false, "Collapse completed sets"],
+  show_account_stats: [false, "Show selected account stats"],
+};
 const styles = `
   :host { display: block; color: var(--primary-text-color, #202830); font-family: var(--paper-font-body1_-_font-family, system-ui, sans-serif); }
   * { box-sizing: border-box; }
@@ -37,15 +46,23 @@ const styles = `
   .exercise-head { margin-bottom: 14px; }
   .exercise-head button, .remove-set { font-size: 12px; min-height: 44px; padding: 8px 10px; }
   .sets { display: grid; gap: 8px; }
-  .set { display: grid; grid-template-columns: 44px repeat(3, minmax(0, 1fr)) 44px; gap: 8px; align-items: end; border-radius: 10px; padding: 8px; background: var(--secondary-background-color, #f3f6f8); }
+  .set { display: grid; grid-template-columns: 44px minmax(0, 1fr) 44px; gap: 8px; align-items: center; border-radius: 10px; padding: 8px; background: var(--secondary-background-color, #f3f6f8); }
+  .set-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+  .set.collapsed { grid-template-columns: 44px minmax(0, 1fr); }
+  .set-summary { text-align: left; border: 0; display: grid; gap: 4px; overflow-wrap: anywhere; }
+  .set-summary .hint { margin: 0; }
+  .collapse-set { grid-column: 1 / -1; }
+  .account-name { margin-top: 8px; overflow-wrap: anywhere; }
+  .account-stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 0 24px 20px; padding: 14px; border: 1px solid var(--divider-color, #dde3e7); border-radius: 10px; }
+  .account-stats dt { font-size: 12px; color: var(--secondary-text-color, #64717b); }
+  .account-stats dd { margin: 6px 0 0; font-size: 20px; font-weight: 600; }
+  .settings { border: 0; border-top: 1px solid var(--divider-color, #dde3e7); padding: 16px 0 0; margin: 0; min-width: 0; }
+  .settings legend { font-size: 16px; font-weight: 600; padding: 0 8px 0 0; }
   .set.done { box-shadow: inset 3px 0 0 var(--primary-color, #167b74); }
   .set label { font-size: 11px; gap: 5px; }
   .set input:not([type=checkbox]), .set select { min-width: 0; padding: 8px; background: var(--ha-card-background, var(--card-background-color, #fff)); }
   .set .completion { align-self: stretch; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 7px; padding: 4px; }
-  .set .set-type { grid-column: 2 / 4; }
-  .set .optional { grid-column: 4 / 5; }
-  .set .remove-set { grid-column: 5; grid-row: 1 / 3; align-self: center; padding: 8px; }
-  .set .completion { grid-row: 1 / 3; }
+  .set .remove-set { padding: 8px; }
   .exercise-actions { margin-top: 10px; }
   details { margin-top: 12px; }
   summary { cursor: pointer; min-height: 44px; display: flex; align-items: center; font-size: 13px; color: var(--secondary-text-color, #64717b); }
@@ -64,11 +81,10 @@ const styles = `
     header, main, footer { padding-left: 16px; padding-right: 16px; }
     .notice { margin-left: 16px; margin-right: 16px; }
     h1 { font-size: 21px; }
-    .set { grid-template-columns: 36px repeat(3, minmax(0, 1fr)); gap: 6px; padding: 8px 6px; }
-    .set .remove-set { grid-column: 4; grid-row: 1; align-self: end; min-height: 46px; }
-    .set .optional { grid-column: 4; }
-    .set .set-type { grid-column: 2 / 4; }
-    .set .completion { grid-row: 1 / 3; }
+    .set { grid-template-columns: 32px minmax(0, 1fr) 32px; gap: 6px; padding: 8px 6px; }
+    .set.collapsed { grid-template-columns: 32px minmax(0, 1fr); }
+    .set .remove-set { min-height: 46px; }
+    .account-stats { margin-left: 16px; margin-right: 16px; }
     .row.actions > button { flex: 1; }
   }
   @media (prefers-reduced-motion: reduce) { .progress > span { transition: none; } }
@@ -87,6 +103,7 @@ class HevyWorkoutCard extends HTMLElement {
     this._error = "";
     this._search = "";
     this._invalid = new Map();
+    this._expandedSets = new Set();
     this._requestVersion = 0;
     this.shadowRoot.addEventListener("click", (event) => this._click(event));
     this.shadowRoot.addEventListener("input", (event) => this._input(event));
@@ -99,6 +116,9 @@ class HevyWorkoutCard extends HTMLElement {
 
   setConfig(config) {
     if (!config || typeof config !== "object") throw new Error("Card configuration is required.");
+    for (const key of Object.keys(boardOptions)) {
+      if (config[key] !== undefined && typeof config[key] !== "boolean") throw new Error(`${boardOptions[key][1]} must be true or false.`);
+    }
     const previous = this._config.config_entry_id;
     this._config = { ...config };
     if (previous !== config.config_entry_id || !this._board) {
@@ -139,6 +159,11 @@ class HevyWorkoutCard extends HTMLElement {
 
   get _dirty() { return this._editVersion !== this._savedVersion; }
   get _online() { return (this._hass?.connection?.connected ?? this._hass?.connected) !== false; }
+  _option(key) { return this._config[key] ?? boardOptions[key][0]; }
+
+  _accountTitle() {
+    return this._board?.accounts?.find((account) => account.config_entry_id === this._entry)?.title || "Hevy account";
+  }
 
   _reset(entry) {
     this._epoch += 1;
@@ -153,6 +178,7 @@ class HevyWorkoutCard extends HTMLElement {
     this._error = "";
     this._confirm = "";
     this._invalid.clear();
+    this._expandedSets.clear();
     this._needsLoad = true;
     clearTimeout(this._saveTimer);
   }
@@ -187,6 +213,7 @@ class HevyWorkoutCard extends HTMLElement {
       this._entry = board.config_entry_id || this._entry;
       if (!this._dirty && !this._saving) {
         this._draft = board.session ? copy(board.session) : null;
+        if (oldId !== this._draft?.id) this._expandedSets.clear();
         this._conflict = false;
       } else if (board.session?.id !== oldId || board.session?.revision !== oldRevision) {
         this._conflict = true;
@@ -194,6 +221,7 @@ class HevyWorkoutCard extends HTMLElement {
         this._error = "This workout changed on another screen. Your unsaved edits are still here. Load the saved session to continue.";
       }
       if (!quiet || oldRevision !== this._draft?.revision || oldId !== this._draft?.id || oldStatus !== this._draft?.status || this._conflict) this._render();
+      else this._renderStats();
     } catch (error) {
       if (epoch !== this._epoch) return;
       this._error = this._message(error, "Could not load your workout. Check the Home Assistant connection.");
@@ -336,15 +364,22 @@ class HevyWorkoutCard extends HTMLElement {
         if (target.value) set.rpe = Number(target.value);
         else delete set.rpe;
       } else set[field] = field === "completed" ? target.checked : target.value;
-      if (field === "completed") target.closest(".set").classList.toggle("done", target.checked);
+      if (field === "completed") {
+        const key = `${target.dataset.exercise}:${target.dataset.set}`;
+        this._expandedSets.delete(key);
+        this._renderSet(Number(target.dataset.exercise), Number(target.dataset.set));
+        this.shadowRoot.querySelector(`[data-field="completed"][data-exercise="${target.dataset.exercise}"][data-set="${target.dataset.set}"]`)?.focus({ preventScroll: true });
+      }
     } else return;
     this._changed();
   }
 
   async _switchAccount(entry) {
     if (this._actionBusy) return;
+    this._actionBusy = true;
+    this._render();
     await this._save();
-    if (this._dirty || this._saveError) { this._render(); return; }
+    if (this._dirty || this._saveError) { this._actionBusy = false; this._render(); return; }
     this._reset(entry);
     this._render();
     await this._load();
@@ -377,7 +412,7 @@ class HevyWorkoutCard extends HTMLElement {
     }
     else if (action === "start") {
       const routine = this.shadowRoot.querySelector("[data-action=routine]").value;
-      void this._action("start_workout", routine ? { routine_id: routine } : {});
+      void this._action("start_workout", { ...(routine ? { routine_id: routine } : {}), is_private: this._option("default_private_workout") });
     }
     else if (action === "add-exercise") {
       const id = this.shadowRoot.querySelector("[data-action=exercise]").value;
@@ -397,16 +432,28 @@ class HevyWorkoutCard extends HTMLElement {
     else if (action === "remove-set") {
       if (this._draft.exercises[exerciseIndex].sets.length <= 1) return;
       this._draft.exercises[exerciseIndex].sets.splice(Number(button.dataset.set), 1);
+      this._expandedSets.clear();
       this._changed();
       this._render();
     }
     else if (action === "remove-exercise") {
+      if (!this._option("show_remove_exercise")) return;
       this._showConfirmation(`remove:${exerciseIndex}`);
     }
     else if (action === "remove-confirm") {
+      if (!this._option("show_remove_exercise")) return;
       this._draft.exercises.splice(exerciseIndex, 1);
+      this._expandedSets.clear();
       this._changed();
       this._render();
+    }
+    else if (action === "expand-set" || action === "collapse-set") {
+      const setIndex = Number(button.dataset.set);
+      const key = `${exerciseIndex}:${setIndex}`;
+      if (action === "expand-set") this._expandedSets.add(key);
+      else this._expandedSets.delete(key);
+      this._renderSet(exerciseIndex, setIndex);
+      this.shadowRoot.querySelector(`[data-field="completed"][data-exercise="${exerciseIndex}"][data-set="${setIndex}"]`)?.focus({ preventScroll: true });
     }
     else if (["finish", "cancel", "retry", "discard"].includes(action)) this._showConfirmation(action);
     else if (action === "dismiss") { this._confirm = ""; this._render(); }
@@ -474,7 +521,7 @@ class HevyWorkoutCard extends HTMLElement {
     return `<label>${label}<input type="number" inputmode="${integer ? "numeric" : "decimal"}" min="0" max="1000000" ${this._invalid.has(key) ? 'aria-invalid="true"' : ""} step="${integer ? "1" : field === "rpe" ? "0.5" : "any"}" value="${escapeHTML(value)}" aria-label="${escapeHTML(label)} for set ${index + 1} of ${escapeHTML(this._draft.exercises[exercise].name)}" data-field="${field}" data-exercise="${exercise}" data-set="${index}" ${disabled}></label>`;
   }
 
-  _exercise(exercise, index, disabled) {
+  _measurementFields(exercise) {
     const metadata = this._board.exercises.find((item) => item.id === exercise.exercise_template_id);
     const kind = metadata?.type || "weight_reps";
     const duration = kind.includes("duration") || exercise.sets.some((set) => set.duration_seconds != null);
@@ -486,7 +533,48 @@ class HevyWorkoutCard extends HTMLElement {
     if (reps) fields.push(["reps", "Reps"]);
     if (duration) fields.push(["duration_seconds", "Time (sec)"]);
     if (distance) fields.push(["distance", `Distance (${escapeHTML(this._draft.distance_unit)})`]);
-    return `<section class="exercise"><div class="row spread exercise-head"><h3>${escapeHTML(exercise.name)}</h3><button class="danger" data-action="remove-exercise" data-exercise="${index}" aria-label="Remove ${escapeHTML(exercise.name)}" ${disabled}>Remove</button></div><div class="sets">${exercise.sets.map((set, setIndex) => `<div class="set ${set.completed ? "done" : ""}"><label class="completion"><span>Set ${setIndex + 1}</span><input type="checkbox" data-field="completed" data-exercise="${index}" data-set="${setIndex}" aria-label="Complete set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${set.completed ? "checked" : ""} ${disabled}></label>${fields.map(([field, label]) => this._numeric(field, label, set, index, setIndex, disabled)).join("")}<label class="set-type">Set type<select data-field="type" data-exercise="${index}" data-set="${setIndex}" aria-label="Type for set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${disabled}>${setTypes.map((type) => `<option value="${type}" ${type === set.type ? "selected" : ""}>${type[0].toUpperCase() + type.slice(1)}</option>`).join("")}</select></label><div class="optional">${this._numeric("rpe", "RPE", set, index, setIndex, disabled)}</div><button class="remove-set danger" data-action="remove-set" data-exercise="${index}" data-set="${setIndex}" aria-label="Remove set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${disabled || (exercise.sets.length <= 1 ? "disabled" : "")}>×</button></div>`).join("")}</div><div class="exercise-actions"><button data-action="add-set" data-exercise="${index}" ${disabled}>+ Add set</button></div><details><summary>Exercise notes</summary><label>Notes<textarea data-field="notes" data-exercise="${index}" aria-label="Notes for ${escapeHTML(exercise.name)}" maxlength="2000" ${disabled}>${escapeHTML(exercise.notes || "")}</textarea></label></details></section>`;
+    return fields;
+  }
+
+  _set(exercise, index, setIndex, disabled) {
+    const set = exercise.sets[setIndex];
+    const key = `${index}:${setIndex}`;
+    const invalid = [...this._invalid.keys()].some((field) => field.endsWith(`:${key}`));
+    const collapsible = this._option("collapse_completed_sets") && set.completed && !invalid;
+    const collapsed = collapsible && !this._expandedSets.has(key);
+    const completion = `<label class="completion"><span>Set ${setIndex + 1}</span><input type="checkbox" data-field="completed" data-exercise="${index}" data-set="${setIndex}" aria-label="Complete set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${set.completed ? "checked" : ""} ${disabled}></label>`;
+    if (collapsed) {
+      const measurements = [["weight", this._draft.weight_unit], ["reps", "reps"], ["duration_seconds", "sec"], ["distance", this._draft.distance_unit]].filter(([field]) => set[field] != null).map(([field, unit]) => `${set[field]} ${unit}`).join(" · ");
+      return `<div class="set done collapsed" data-set-row="${key}">${completion}<button class="set-summary" data-action="expand-set" data-exercise="${index}" data-set="${setIndex}" aria-expanded="false" aria-label="Show details for set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${disabled}><span>${escapeHTML(measurements)}</span><span class="hint">Show details</span></button></div>`;
+    }
+    const type = this._option("show_set_type") ? `<label>Set type<select data-field="type" data-exercise="${index}" data-set="${setIndex}" aria-label="Type for set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${disabled}>${setTypes.map((type) => `<option value="${type}" ${type === set.type ? "selected" : ""}>${type[0].toUpperCase() + type.slice(1)}</option>`).join("")}</select></label>` : "";
+    const rpe = this._option("show_rpe") ? this._numeric("rpe", "RPE", set, index, setIndex, disabled) : "";
+    const collapse = collapsible ? `<button class="collapse-set" data-action="collapse-set" data-exercise="${index}" data-set="${setIndex}" aria-expanded="true" ${disabled}>Hide details</button>` : "";
+    return `<div class="set ${set.completed ? "done" : ""}" data-set-row="${key}">${completion}<div class="set-fields">${this._measurementFields(exercise).map(([field, label]) => this._numeric(field, label, set, index, setIndex, disabled)).join("")}${type}${rpe}${collapse}</div><button class="remove-set danger" data-action="remove-set" data-exercise="${index}" data-set="${setIndex}" aria-label="Remove set ${setIndex + 1} of ${escapeHTML(exercise.name)}" ${disabled || (exercise.sets.length <= 1 ? "disabled" : "")}>×</button></div>`;
+  }
+
+  _renderSet(index, setIndex) {
+    const row = this.shadowRoot.querySelector(`[data-set-row="${index}:${setIndex}"]`);
+    const exercise = this._draft?.exercises[index];
+    if (row && exercise?.sets[setIndex]) {
+      const disabled = this._actionBusy || !this._online || this._draft.status !== "active" ? "disabled" : "";
+      row.outerHTML = this._set(exercise, index, setIndex, disabled);
+    }
+  }
+
+  _exercise(exercise, index, disabled) {
+    const remove = this._option("show_remove_exercise") ? `<button class="danger" data-action="remove-exercise" data-exercise="${index}" aria-label="Remove ${escapeHTML(exercise.name)}" ${disabled}>Remove</button>` : "";
+    return `<section class="exercise"><div class="row spread exercise-head"><h3>${escapeHTML(exercise.name)}</h3>${remove}</div><div class="sets">${exercise.sets.map((_, setIndex) => this._set(exercise, index, setIndex, disabled)).join("")}</div><div class="exercise-actions"><button data-action="add-set" data-exercise="${index}" ${disabled}>+ Add set</button></div><details><summary>Exercise notes</summary><label>Notes<textarea data-field="notes" data-exercise="${index}" aria-label="Notes for ${escapeHTML(exercise.name)}" maxlength="2000" ${disabled}>${escapeHTML(exercise.notes || "")}</textarea></label></details></section>`;
+  }
+
+  _renderStats() {
+    const region = this.shadowRoot.querySelector("[data-account-stats]");
+    if (!region) return;
+    const stats = this._board?.stats || {};
+    region.innerHTML = [["workout_count", "Total workouts"], ["weekly_workout_count", "Last 7 days"], ["current_streak", "Streak (days)"]].map(([key, label]) => {
+      const available = typeof stats[key] === "number" && Number.isFinite(stats[key]);
+      return `<div><dt>${label}</dt><dd class="${available ? "" : "muted"}">${available ? escapeHTML(stats[key]) : "Unavailable"}</dd></div>`;
+    }).join("");
   }
 
   _confirmation() {
@@ -498,7 +586,7 @@ class HevyWorkoutCard extends HTMLElement {
     let extra = "";
     if (this._confirm === "finish") {
       title = "Finish this workout?";
-      text = `${this._count().completed} completed sets will be sent to Hevy. Unchecked sets will be left out.`;
+      text = `${this._count().completed} completed ${this._count().completed === 1 ? "set" : "sets"} will be sent to ${this._accountTitle()} as a ${this._draft.is_private ? "private" : "public"} workout. Unchecked sets will be left out.`;
       action = "finish-confirm";
       label = "Finish and send to Hevy";
     } else if (this._confirm === "cancel") {
@@ -551,12 +639,13 @@ class HevyWorkoutCard extends HTMLElement {
     } else if (draft.status === "submitting") {
       content = `<div class="intro" role="status"><h2>Sending your workout...</h2><p>Keep this session open. Its saved status will update automatically.</p></div>`;
     } else {
-      content = `<div class="stack"><label>Workout title<input data-field="title" value="${escapeHTML(this._invalid.has("title::") ? this._invalid.get("title::") : draft.title)}" required maxlength="200" ${this._invalid.has("title::") ? 'aria-invalid="true"' : ""} ${disabled}></label><label class="check"><input type="checkbox" data-field="is_private" ${draft.is_private ? "checked" : ""} ${disabled}>Private workout</label></div>${draft.exercises.length ? draft.exercises.map((exercise, index) => this._exercise(exercise, index, disabled)).join("") : '<p class="empty">Add your first exercise below, then check off each set as you finish it.</p>'}<section class="picker stack"><h3>Add an exercise</h3><label>Search exercises<input data-action="search" type="search" value="${escapeHTML(this._search)}" placeholder="Name or muscle group" ${disabled}></label><label>Exercise<select data-action="exercise" ${disabled}>${this._exerciseOptions()}</select></label><button data-action="add-exercise" ${disabled}>+ Add exercise</button></section>`;
+      content = `<div class="stack"><label>Workout title<input data-field="title" value="${escapeHTML(this._invalid.has("title::") ? this._invalid.get("title::") : draft.title)}" required maxlength="200" ${this._invalid.has("title::") ? 'aria-invalid="true"' : ""} ${disabled}></label>${this._option("show_private_workout") ? `<label class="check"><input type="checkbox" data-field="is_private" ${draft.is_private ? "checked" : ""} ${disabled}>Private workout</label>` : ""}</div>${draft.exercises.length ? draft.exercises.map((exercise, index) => this._exercise(exercise, index, disabled)).join("") : '<p class="empty">Add your first exercise below, then check off each set as you finish it.</p>'}<section class="picker stack"><h3>Add an exercise</h3><label>Search exercises<input data-action="search" type="search" value="${escapeHTML(this._search)}" placeholder="Name or muscle group" ${disabled}></label><label>Exercise<select data-action="exercise" ${disabled}>${this._exerciseOptions()}</select></label><button data-action="add-exercise" ${disabled}>+ Add exercise</button></section>`;
       footer = `<div class="row spread"><span class="muted" data-count></span><span class="saved" data-save-status role="status" aria-live="polite"></span></div><div class="progress" aria-hidden="true"><span></span></div><div class="row actions"><button class="danger" data-action="cancel" ${busy}>Discard session</button><button class="primary" data-action="finish" ${busy}>Finish workout</button></div>`;
     }
-    this.shadowRoot.innerHTML = `<style>${styles}</style><ha-card><header><div><p class="eyebrow">Hevy · Workout board</p><h1>${escapeHTML(this._config.title || "Workout")}</h1></div>${draft ? `<span class="badge">${escapeHTML(({ active: "In progress", submitting: "Sending", uncertain: "Check Hevy", finished: "Finished" })[draft.status] || draft.status)}</span>` : ""}</header><div data-errors></div>${accounts.length > 1 ? `<div class="notice"><label>Hevy account<select data-action="account" ${busy}><option value="">Choose an account</option>${accounts.map((account) => `<option value="${escapeHTML(account.config_entry_id)}" ${account.config_entry_id === this._entry ? "selected" : ""}>${escapeHTML(account.title)}</option>`).join("")}</select></label></div>` : ""}<main>${content}</main>${footer || this._confirm ? `<footer>${footer}${this._confirmation()}</footer>` : ""}</ha-card>`;
+    this.shadowRoot.innerHTML = `<style>${styles}</style><ha-card><header><div><p class="eyebrow">Hevy · Workout board</p><h1>${escapeHTML(this._config.title || "Workout")}</h1>${this._entry && this._board ? `<p class="muted account-name">${escapeHTML(this._accountTitle())}</p>` : ""}</div>${draft ? `<span class="badge">${escapeHTML(({ active: "In progress", submitting: "Sending", uncertain: "Check Hevy", finished: "Finished" })[draft.status] || draft.status)}</span>` : ""}</header><div data-errors></div>${accounts.length > 1 ? `<div class="notice"><label>Who is working out?<select data-action="account" ${busy}><option value="">Choose an account</option>${accounts.map((account) => `<option value="${escapeHTML(account.config_entry_id)}" ${account.config_entry_id === this._entry ? "selected" : ""}>${escapeHTML(account.title)}</option>`).join("")}</select></label></div>` : ""}${this._option("show_account_stats") && this._entry ? `<dl class="account-stats" data-account-stats aria-label="Stats for ${escapeHTML(this._accountTitle())}"></dl>` : ""}<main>${content}</main>${footer || this._confirm ? `<footer>${footer}${this._confirmation()}</footer>` : ""}</ha-card>`;
     this._renderError();
     this._status();
+    this._renderStats();
   }
 }
 
@@ -568,9 +657,10 @@ class HevyWorkoutCardEditor extends HTMLElement {
     this.shadowRoot.addEventListener("change", (event) => {
       const key = event.target.dataset.config;
       if (!key) return;
-      const value = event.target.value.trim();
+      const value = event.target.type === "checkbox" ? event.target.checked : event.target.value.trim();
       this._config = { ...this._config };
-      if (key.endsWith("_ids")) {
+      if (key in boardOptions) this._config[key] = value;
+      else if (key.endsWith("_ids")) {
         const ids = value.split(",").map((id) => id.trim()).filter(Boolean);
         if (ids.length) this._config[key] = ids;
         else delete this._config[key];
@@ -595,7 +685,7 @@ class HevyWorkoutCardEditor extends HTMLElement {
 
   _render() {
     const config = this._config;
-    this.shadowRoot.innerHTML = `<style>${styles}</style><div class="stack"><label>Title<input data-config="title" value="${escapeHTML(config.title || "Workout")}"></label><label>Hevy account${this._accountList ? `<select data-config="config_entry_id"><option value="">Choose on the card</option>${this._accountList.map((account) => `<option value="${escapeHTML(account.config_entry_id)}" ${account.config_entry_id === config.config_entry_id ? "selected" : ""}>${escapeHTML(account.title)}</option>`).join("")}</select>` : `<input data-config="config_entry_id" value="${escapeHTML(config.config_entry_id || "")}" placeholder="Optional config entry ID">`}</label><label>Favorite routine IDs<input data-config="routine_ids" value="${escapeHTML((config.routine_ids || []).join(", "))}" placeholder="Comma-separated IDs"></label><label>Favorite exercise IDs<input data-config="exercise_ids" value="${escapeHTML((config.exercise_ids || []).join(", "))}" placeholder="Comma-separated IDs"></label><p class="hint">Favorites appear first in the pickers. Other routines and exercises remain available. Sessions are saved in Home Assistant for the selected account.</p></div>`;
+    this.shadowRoot.innerHTML = `<style>${styles}</style><div class="stack"><label>Title<input data-config="title" value="${escapeHTML(config.title || "Workout")}"></label><label>Hevy account${this._accountList ? `<select data-config="config_entry_id"><option value="">Choose on the card</option>${this._accountList.map((account) => `<option value="${escapeHTML(account.config_entry_id)}" ${account.config_entry_id === config.config_entry_id ? "selected" : ""}>${escapeHTML(account.title)}</option>`).join("")}</select>` : `<input data-config="config_entry_id" value="${escapeHTML(config.config_entry_id || "")}" placeholder="Optional config entry ID">`}</label><label>Favorite routine IDs<input data-config="routine_ids" value="${escapeHTML((config.routine_ids || []).join(", "))}" placeholder="Comma-separated IDs"></label><label>Favorite exercise IDs<input data-config="exercise_ids" value="${escapeHTML((config.exercise_ids || []).join(", "))}" placeholder="Comma-separated IDs"></label><p class="hint">Favorites appear first in the pickers. Other routines and exercises remain available. Sessions are saved in Home Assistant for the selected account.</p><fieldset class="settings"><legend>Board display</legend>${Object.entries(boardOptions).map(([key, [fallback, label]]) => `<label class="check"><input type="checkbox" data-config="${key}" ${(config[key] ?? fallback) ? "checked" : ""}>${label}</label>`).join("")}<p class="hint">The privacy default applies when starting a new workout. Saved sessions keep their privacy setting. Hidden set type and RPE values are preserved.</p></fieldset></div>`;
   }
 }
 

--- a/custom_components/hevy/manifest.json
+++ b/custom_components/hevy/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "aiohttp>=3.9.0"
   ],
-  "version": "1.4.0"
+  "version": "1.5.0"
 }

--- a/custom_components/hevy/services.yaml
+++ b/custom_components/hevy/services.yaml
@@ -136,6 +136,12 @@ start_workout:
       name: Title
       selector:
         text: null
+    is_private:
+      name: Private workout
+      description: Sets the visibility for this new session. Saved sessions keep this value.
+      default: false
+      selector:
+        boolean: null
 update_workout:
   name: Update workout
   description: Saves the full workout draft. Stale revisions are rejected to protect

--- a/custom_components/hevy/session_services.py
+++ b/custom_components/hevy/session_services.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 
-from .const import DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
 from .workout_session import (
     SESSION_EXERCISES_SCHEMA,
     TITLE,
@@ -40,7 +40,14 @@ def register_session_services(hass: HomeAssistant) -> None:
 
     async def board(call: ServiceCall) -> dict[str, Any]:
         accounts = [
-            {"config_entry_id": entry.entry_id, "title": entry.title}
+            {
+                "config_entry_id": entry.entry_id,
+                "title": (
+                    entry.title
+                    if entry.title != DEFAULT_NAME
+                    else hass.data[DOMAIN][entry.entry_id].account_name or entry.title
+                ),
+            }
             for entry in hass.config_entries.async_entries(DOMAIN)
             if entry.entry_id in hass.data.get(DOMAIN, {})
         ]
@@ -54,6 +61,7 @@ def register_session_services(hass: HomeAssistant) -> None:
         next_workout = (
             coordinator.data.get("routine_data", {}) if coordinator.data else {}
         )
+        data = coordinator.data or {}
         return {
             "accounts": accounts,
             "config_entry_id": entry_id,
@@ -81,13 +89,23 @@ def register_session_services(hass: HomeAssistant) -> None:
             ),
             "session": current.snapshot(),
             "next_routine_id": next_workout.get("routine_id"),
+            "stats": {
+                key: data.get(key) if coordinator.last_update_success else None
+                for key in (
+                    "workout_count",
+                    "weekly_workout_count",
+                    "current_streak",
+                )
+            },
         }
 
     async def mutate(call: ServiceCall) -> dict[str, Any]:
         current = manager(call.data["config_entry_id"])
         if call.service == "start_workout":
             session = await current.start(
-                call.data.get("routine_id"), call.data.get("title")
+                call.data.get("routine_id"),
+                call.data.get("title"),
+                call.data["is_private"],
             )
         elif call.service == "update_workout":
             session = await current.update(
@@ -112,6 +130,7 @@ def register_session_services(hass: HomeAssistant) -> None:
             **ENTRY,
             vol.Optional("routine_id"): TITLE,
             vol.Optional("title"): TITLE,
+            vol.Optional("is_private", default=False): bool,
         },
         "update_workout": {
             **CURRENT,

--- a/custom_components/hevy/workout_session.py
+++ b/custom_components/hevy/workout_session.py
@@ -171,7 +171,9 @@ class WorkoutSession:
                     )
         return result
 
-    async def start(self, routine_id: str | None, title: str | None) -> dict:
+    async def start(
+        self, routine_id: str | None, title: str | None, is_private: bool = False
+    ) -> dict:
         async with self.lock:
             if self.closed or self.session:
                 raise ServiceValidationError(
@@ -195,7 +197,7 @@ class WorkoutSession:
                 "start_time": dt_util.utcnow().isoformat(),
                 "weight_unit": self.coordinator._get_weight_unit(),
                 "distance_unit": self.coordinator._get_distance_unit(),
-                "is_private": False,
+                "is_private": is_private,
                 "exercises": self._exercises(
                     routine_exercises(self.coordinator, routine) if routine else []
                 ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 @pytest.fixture
 def mock_client() -> MagicMock:
     client = MagicMock()
+    client.get_user_info = AsyncMock(return_value={"data": {"name": "Test account"}})
     client.get_workout_count = AsyncMock(return_value=0)
     client.get_workouts = AsyncMock(return_value={"workouts": [], "page_count": 1})
     client.get_workout_events = AsyncMock(return_value={"events": []})

--- a/tests/frontend/preview.html
+++ b/tests/frontend/preview.html
@@ -27,15 +27,19 @@
       { exercise_template_id: "bench", name: "Bench Press (Barbell)", sets: [1, 2, 3].map(() => ({ type: "normal", weight: 60, reps: 8, completed: false })) },
       { exercise_template_id: "row", name: "Bent Over Row (Dumbbell)", sets: [1, 2, 3].map(() => ({ type: "normal", weight: 22, reps: 10, completed: false })) },
     ] }];
-    let session = JSON.parse(localStorage.getItem("hevy-card-preview") || "null");
+    const accounts = [{ config_entry_id: "preview", title: "Alex" }, { config_entry_id: "sam", title: "Sam" }];
+    const sessions = JSON.parse(localStorage.getItem("hevy-card-preview-accounts") || "{}");
+    const customized = new URLSearchParams(location.search).has("customized");
     const card = document.querySelector("hevy-workout-card");
-    card.setConfig({ type: "custom:hevy-workout-card", title: "Today's training", config_entry_id: "preview" });
+    card.setConfig({ type: "custom:hevy-workout-card", title: "Today's training", ...(customized ? { show_remove_exercise: false, show_set_type: false, show_rpe: false, show_private_workout: false, default_private_workout: true, collapse_completed_sets: true, show_account_stats: true } : {}) });
     card.hass = {
       connected: true,
       callWS: async ({ service, service_data: data }) => {
         await new Promise((resolve) => setTimeout(resolve, 100));
-        if (service === "get_workout_board") return { response: { accounts: [{ config_entry_id: "preview", title: "Preview" }], config_entry_id: "preview", weight_unit: "kg", distance_unit: "km", exercises, routines, session: structuredClone(session), next_routine_id: "upper" } };
-        if (service === "start_workout") session = { id: crypto.randomUUID(), revision: 1, status: "active", title: data.routine_id ? "Upper body A" : "Workout", start_time: new Date().toISOString(), weight_unit: "kg", distance_unit: "km", is_private: true, exercises: data.routine_id ? structuredClone(routines[0].exercises) : [] };
+        const entry = data.config_entry_id;
+        let session = sessions[entry] || null;
+        if (service === "get_workout_board") return { response: entry ? { accounts, config_entry_id: entry, weight_unit: "kg", distance_unit: "km", exercises, routines, session: structuredClone(session), next_routine_id: "upper", stats: { workout_count: entry === "preview" ? 42 : 18, weekly_workout_count: entry === "preview" ? 3 : 1, current_streak: entry === "preview" ? 2 : 0 } } : { accounts, config_entry_id: null } };
+        if (service === "start_workout") session = { id: crypto.randomUUID(), revision: 1, status: "active", title: data.routine_id ? "Upper body A" : "Workout", start_time: new Date().toISOString(), weight_unit: "kg", distance_unit: "km", is_private: data.is_private ?? false, exercises: data.routine_id ? structuredClone(routines[0].exercises) : [] };
         if (service === "update_workout") {
           if (data.revision !== session.revision) throw new Error("This workout changed on another screen.");
           session = { ...session, ...data, revision: session.revision + 1 };
@@ -43,7 +47,8 @@
         if (service === "finish_workout") session = { ...session, revision: session.revision + 1, status: "finished", workout_id: "preview-workout" };
         if (service === "cancel_workout" || (service === "resolve_workout" && data.resolution === "discard")) session = null;
         if (service === "resolve_workout" && data.resolution === "retry") session = { ...session, revision: session.revision + 1, status: "active" };
-        localStorage.setItem("hevy-card-preview", JSON.stringify(session));
+        sessions[entry] = session;
+        localStorage.setItem("hevy-card-preview-accounts", JSON.stringify(sessions));
         return { response: { session: structuredClone(session) } };
       },
     };

--- a/tests/frontend/workout-card.test.js
+++ b/tests/frontend/workout-card.test.js
@@ -39,7 +39,7 @@ async function setup(t, initial = board(), override) {
     if (service === "update_workout") {
       if (data.revision !== state.session.revision) throw new Error("Session changed. Refresh before trying again.");
       state.session = { ...state.session, ...clone(data), revision: data.revision + 1 };
-    } else if (service === "start_workout") state.session = session();
+    } else if (service === "start_workout") state.session = { ...session(), is_private: data.is_private ?? false };
     else if (service === "finish_workout") state.session = { ...state.session, status: "finished", revision: state.session.revision + 1, workout_id: "hevy-123" };
     else if (service === "cancel_workout") state.session = null;
     else if (service === "resolve_workout") state.session = data.resolution === "retry" ? { ...state.session, status: "active", revision: state.session.revision + 1 } : null;
@@ -128,7 +128,7 @@ test("requires finish confirmation, flushes edits, and sends only one finish req
   ctx.input("[data-field=completed]", true, "change");
   ctx.click("finish");
   assert.equal(ctx.calls.some((call) => call.service === "finish_workout"), false);
-  assert.match(ctx.card.shadowRoot.textContent, /1 completed sets will be sent/);
+  assert.match(ctx.card.shadowRoot.textContent, /1 completed set will be sent/);
   ctx.click("finish-confirm");
   ctx.click("finish-confirm");
   await tick();
@@ -355,4 +355,160 @@ test("finish brings its confirmation into view without submitting the workout", 
   assert.equal(scrolled.options.block, "nearest");
   assert.match(panel.textContent, /Finish and send to Hevy/);
   assert.equal(calls.some((call) => call.service === "finish_workout"), false);
+});
+
+test("board controls keep their existing defaults and reject string booleans", async (t) => {
+  const ctx = await setup(t);
+  for (const selector of ['[data-action="remove-exercise"]', '[data-field="type"]', '[data-field="rpe"]', '[data-field="is_private"]']) assert.ok(ctx.card.shadowRoot.querySelector(selector));
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-account-stats]"), null);
+  assert.throws(() => ctx.card.setConfig({ show_rpe: "false" }), /true or false/);
+});
+
+test("hiding controls preserves routine values and saved privacy when edited", async (t) => {
+  const initial = board();
+  initial.session.exercises[0].sets[0].type = "warmup";
+  initial.session.exercises[0].sets[0].rpe = 8.5;
+  const ctx = await setup(t, initial);
+  ctx.card.setConfig({ config_entry_id: "one", show_remove_exercise: false, show_set_type: false, show_rpe: false, show_private_workout: false, default_private_workout: false });
+  await tick();
+  for (const selector of ['[data-action="remove-exercise"]', '[data-field="type"]', '[data-field="rpe"]', '[data-field="is_private"]']) assert.equal(ctx.card.shadowRoot.querySelector(selector), null);
+  ctx.input("[data-field=weight]", 72);
+  ctx.input("[data-field=completed]", true, "change");
+  await ctx.card._save();
+  assert.equal(ctx.state.session.exercises[0].sets[0].type, "warmup");
+  assert.equal(ctx.state.session.exercises[0].sets[0].rpe, 8.5);
+  assert.equal(ctx.state.session.is_private, true);
+  ctx.click("finish");
+  assert.match(ctx.card.shadowRoot.querySelector(".finish-panel").textContent, /Zach as a private workout/);
+});
+
+for (const isPrivate of [true, false]) {
+  test(`starts with an explicit ${isPrivate ? "private" : "public"} default and preserves it on resume`, async (t) => {
+    const ctx = await setup(t, board(null));
+    ctx.card.setConfig({ config_entry_id: "one", default_private_workout: isPrivate, show_private_workout: false });
+    await tick();
+    ctx.click("start");
+    await tick();
+    assert.equal(ctx.calls.find((call) => call.service === "start_workout").service_data.is_private, isPrivate);
+    assert.equal(ctx.state.session.is_private, isPrivate);
+    ctx.card.setConfig({ config_entry_id: "one", default_private_workout: !isPrivate });
+    await tick();
+    assert.equal(ctx.card._draft.is_private, isPrivate);
+    assert.equal(ctx.card.shadowRoot.querySelector("[data-field=is_private]").checked, isPrivate);
+  });
+}
+
+test("completed sets collapse, expand for editing, and undo without losing values", async (t) => {
+  const ctx = await setup(t);
+  ctx.card.setConfig({ config_entry_id: "one", collapse_completed_sets: true });
+  await tick();
+  ctx.input("[data-field=completed]", true, "change");
+  assert.match(ctx.card.shadowRoot.querySelector(".set-summary").textContent, /60 kg · 8 reps/);
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-field=weight]"), null);
+  await ctx.card._save();
+  assert.equal(ctx.state.session.exercises[0].sets[0].weight, 60);
+  ctx.click("expand-set");
+  ctx.input("[data-field=weight]", 65);
+  ctx.click("collapse-set");
+  assert.match(ctx.card.shadowRoot.querySelector(".set-summary").textContent, /65 kg/);
+  ctx.input("[data-field=completed]", false, "change");
+  assert.equal(ctx.card.shadowRoot.querySelector(".collapsed"), null);
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-field=weight]").value, "65");
+  await ctx.card._save();
+  assert.equal(ctx.state.session.exercises[0].sets[0].completed, false);
+});
+
+test("completed sets collapse after reload and retain all sets in saves", async (t) => {
+  const initial = board();
+  initial.session.exercises[0].sets.push({ type: "normal", weight: 75, reps: 5, completed: false });
+  initial.session.exercises[0].sets[0].completed = true;
+  const ctx = await setup(t, initial);
+  ctx.card.setConfig({ config_entry_id: "one", collapse_completed_sets: true });
+  await tick();
+  assert.equal(ctx.card.shadowRoot.querySelectorAll(".collapsed").length, 1);
+  ctx.input('[data-field=weight][data-set="1"]', 80);
+  await ctx.card._save();
+  assert.equal(ctx.state.session.exercises[0].sets.length, 2);
+  assert.equal(ctx.state.session.exercises[0].sets[0].completed, true);
+  ctx.card.remove();
+  ctx.dom.window.document.body.append(ctx.card);
+  await tick();
+  assert.equal(ctx.card.shadowRoot.querySelectorAll(".collapsed").length, 1);
+  assert.equal(ctx.card.shadowRoot.querySelector('[data-field=weight][data-set="1"]').value, "80");
+});
+
+test("collapse leaves invalid measurements visible for correction", async (t) => {
+  const ctx = await setup(t);
+  ctx.card.setConfig({ config_entry_id: "one", collapse_completed_sets: true });
+  await tick();
+  ctx.input("[data-field=weight]", 1000001);
+  ctx.input("[data-field=completed]", true, "change");
+  assert.equal(ctx.card.shadowRoot.querySelector(".collapsed"), null);
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-field=weight]").value, "1000001");
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-field=weight]").getAttribute("aria-invalid"), "true");
+});
+
+test("account names and stats follow the selected account and refresh without a session edit", async (t) => {
+  const initial = board();
+  initial.accounts.push({ config_entry_id: "two", title: "Sam <training>" });
+  initial.stats = { workout_count: 42, weekly_workout_count: 3, current_streak: 2 };
+  const ctx = await setup(t, initial);
+  ctx.card.setConfig({ config_entry_id: "one", show_account_stats: true });
+  await tick();
+  assert.match(ctx.card.shadowRoot.querySelector(".account-stats").textContent, /42/);
+  assert.equal(ctx.card.shadowRoot.querySelector(".account-name").textContent, "Zach");
+  const next = clone(initial);
+  next.config_entry_id = "two";
+  next.stats = { workout_count: 8, weekly_workout_count: 1, current_streak: 0 };
+  next.session = { ...session(), id: "sam-session", title: "Sam workout" };
+  ctx.state = next;
+  await ctx.card._switchAccount("two");
+  assert.equal(ctx.card.shadowRoot.querySelector(".account-name").textContent, "Sam <training>");
+  assert.equal(ctx.card.shadowRoot.querySelector("training"), null);
+  assert.deepEqual([...ctx.card.shadowRoot.querySelectorAll(".account-stats dd")].map((element) => element.textContent), ["8", "1", "0"]);
+  ctx.state.stats.workout_count = 9;
+  await ctx.card._load(true);
+  assert.equal(ctx.card.shadowRoot.querySelector(".account-stats dd").textContent, "9");
+  ctx.state.stats = { workout_count: null };
+  await ctx.card._load(true);
+  assert.equal(ctx.card.shadowRoot.querySelector(".account-stats dd").textContent, "Unavailable");
+});
+
+test("visual editor emits real booleans and retains other settings", async (t) => {
+  const { dom } = await setup(t);
+  const editor = dom.window.document.createElement("hevy-workout-card-editor");
+  editor.setConfig({ type: "custom:hevy-workout-card", config_entry_id: "one", routine_ids: ["upper"], default_private_workout: true });
+  let config;
+  editor.addEventListener("config-changed", (event) => { config = event.detail.config; });
+  const field = editor.shadowRoot.querySelector("[data-config=show_rpe]");
+  field.checked = false;
+  field.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+  assert.equal(config.show_rpe, false);
+  assert.equal(config.default_private_workout, true);
+  assert.equal(config.config_entry_id, "one");
+  assert.deepEqual([...config.routine_ids], ["upper"]);
+});
+
+test("account switching blocks submission until pending edits finish saving", async (t) => {
+  const pending = deferred();
+  const initial = board();
+  initial.accounts.push({ config_entry_id: "two", title: "Sam" });
+  initial.session.exercises[0].sets[0].completed = true;
+  const ctx = await setup(t, initial, async (request) => {
+    if (request.service === "update_workout") return pending.promise;
+  });
+  ctx.input("[data-field=weight]", 70);
+  const switching = ctx.card._switchAccount("two");
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-action=account]").value, "one");
+  assert.equal(ctx.card.shadowRoot.querySelector("[data-action=account]").disabled, true);
+  ctx.click("finish");
+  assert.equal(ctx.card.shadowRoot.querySelector(".finish-panel"), null);
+  assert.equal(ctx.calls.filter((call) => call.service === "finish_workout").length, 0);
+  const saved = { ...clone(ctx.card._draft), revision: 2 };
+  ctx.state.config_entry_id = "two";
+  ctx.state.session = { ...session(), id: "sam-session" };
+  pending.resolve({ response: { session: saved } });
+  await switching;
+  assert.equal(ctx.card._entry, "two");
+  assert.equal(ctx.card.shadowRoot.querySelector(".account-name").textContent, "Sam");
 });

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,3 +29,18 @@ async def test_connection_error_does_not_expose_transport_details():
     with pytest.raises(HevyApiError, match="Connection to Hevy failed") as caught:
         await client.get_workout_count()
     assert "sensitive-transport-value" not in str(caught.value)
+
+
+async def test_user_info_uses_authenticated_account_endpoint():
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={"data": {"id": "user-one", "name": "Sam"}})
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    session = MagicMock()
+    session.request.return_value = request
+    client = HevyApiClient("fixture-key", session)
+    assert await client.get_user_info() == {"data": {"id": "user-one", "name": "Sam"}}
+    args, kwargs = session.request.call_args
+    assert args[0] == "GET"
+    assert args[1].endswith("/v1/user/info")
+    assert kwargs["headers"] == {"api-key": "fixture-key"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,6 +30,7 @@ def _sample_workout() -> dict:
 def _patch_api():
     return patch.multiple(
         HevyApiClient,
+        get_user_info=AsyncMock(return_value={"data": {"name": "Test account"}}),
         get_workout_count=AsyncMock(return_value=42),
         get_workouts=AsyncMock(
             return_value={"workouts": [_sample_workout()], "page_count": 1}

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -471,3 +471,129 @@ async def test_repeated_cancel_keeps_writer_locked_until_durable(
     assert reopened.snapshot() == receipt
     assert await reopened.finish(current["id"], current["revision"]) == receipt
     session_manager.coordinator.client.create_workout.assert_awaited_once()
+
+
+@pytest.mark.parametrize("is_private", [True, False])
+async def test_start_privacy_is_saved_before_first_edit(
+    hass, session_manager, is_private
+):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_API_KEY: "privacy-fixture"})
+    entry.add_to_hass(hass)
+    session_manager.coordinator.workout_session = session_manager
+    hass.data[DOMAIN] = {entry.entry_id: session_manager.coordinator}
+    register_session_services(hass)
+    result = await hass.services.async_call(
+        DOMAIN,
+        "start_workout",
+        {
+            "config_entry_id": entry.entry_id,
+            "routine_id": "r1",
+            "is_private": is_private,
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert result["session"]["is_private"] is is_private
+    reopened = WorkoutSession(hass, "entry-one", session_manager.coordinator)
+    await reopened.load()
+    assert reopened.snapshot()["is_private"] is is_private
+    draft = reopened.snapshot()
+    draft["exercises"][0]["sets"][0]["completed"] = True
+    saved = await reopened.update(draft["id"], draft["revision"], draft)
+    await reopened.finish(saved["id"], saved["revision"])
+    payload = session_manager.coordinator.client.create_workout.call_args.args[0]
+    assert payload["workout"]["is_private"] is is_private
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        [],
+        {},
+        {"data": None},
+        {"data": []},
+        {"data": {"name": 2}},
+        {"data": {"name": " "}},
+    ],
+)
+async def test_bad_account_info_keeps_fallback(imperial_coordinator, response):
+    imperial_coordinator.client.get_user_info.return_value = response
+    await imperial_coordinator.fetch_account_name()
+    assert imperial_coordinator.account_name is None
+
+
+async def test_unavailable_account_info_keeps_cached_name(imperial_coordinator):
+    imperial_coordinator.account_name = "Sam"
+    imperial_coordinator.client.get_user_info.side_effect = HevyApiError("Unavailable")
+    await imperial_coordinator.fetch_account_name()
+    assert imperial_coordinator.account_name == "Sam"
+
+
+async def test_account_name_stats_and_sessions_stay_with_selected_entry(
+    hass, imperial_coordinator, metric_coordinator
+):
+    from custom_components.hevy.const import DEFAULT_NAME
+
+    coordinators = [imperial_coordinator, metric_coordinator]
+    entries = []
+    for index, coordinator in enumerate(coordinators):
+        entry = MockConfigEntry(
+            domain=DOMAIN, data={CONF_API_KEY: f"account-{index}"}, title=DEFAULT_NAME
+        )
+        entry.add_to_hass(hass)
+        entries.append(entry)
+        coordinator.client.get_user_info.return_value = {
+            "data": {"name": f" Person {index} "}
+        }
+        await coordinator.fetch_account_name()
+        coordinator.async_set_updated_data(
+            {
+                "workout_count": index + 10,
+                "weekly_workout_count": index + 1,
+                "current_streak": index,
+            }
+        )
+        coordinator.workout_session = WorkoutSession(hass, entry.entry_id, coordinator)
+        await coordinator.workout_session.start(None, f"Workout {index}")
+    hass.data[DOMAIN] = dict(
+        zip([entry.entry_id for entry in entries], coordinators, strict=True)
+    )
+    register_session_services(hass)
+    picker = await hass.services.async_call(
+        DOMAIN, "get_workout_board", {}, blocking=True, return_response=True
+    )
+    assert picker["config_entry_id"] is None
+    assert [account["title"] for account in picker["accounts"]] == [
+        "Person 0",
+        "Person 1",
+    ]
+    for index, entry in enumerate(entries):
+        board = await hass.services.async_call(
+            DOMAIN,
+            "get_workout_board",
+            {"config_entry_id": entry.entry_id},
+            blocking=True,
+            return_response=True,
+        )
+        assert board["session"]["title"] == f"Workout {index}"
+        assert board["stats"] == {
+            "workout_count": index + 10,
+            "weekly_workout_count": index + 1,
+            "current_streak": index,
+        }
+    hass.config_entries.async_update_entry(entries[0], title="My label")
+    imperial_coordinator.last_update_success = False
+    board = await hass.services.async_call(
+        DOMAIN,
+        "get_workout_board",
+        {"config_entry_id": entries[0].entry_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert board["accounts"][0]["title"] == "My label"
+    assert board["stats"] == {
+        "workout_count": None,
+        "weekly_workout_count": None,
+        "current_streak": None,
+    }


### PR DESCRIPTION
## What and why

Make the workout board more customizable with clearer account selection. The visual editor and YAML can hide exercise removal, set type, RPE, and the privacy control; choose a new-workout privacy default; collapse completed sets into editable summaries; and show stats for the selected account. Existing cards retain their display defaults.

Account names come from Hevy's profile endpoint, with integration-entry names as fallbacks and custom labels. The selected account stays visible, and the finish confirmation names the destination and actual privacy. Switching accounts saves pending edits and prevents submission while the switch is in progress. Hidden set values and saved privacy remain intact across reloads and cards.

Closes #35.

## Validation

- `mise run check` and `mise run ci` passed at 396c4074e2b44cae66237fb7a718586633847fab: 157 Python tests and 29 card tests.
- Browser fixture checked at 390px and 768px: hidden controls, collapse and expansion, editing, reload, independent account drafts and stats, and destination/privacy confirmation.
- Semgrep: 0 findings. JavaScript dependency audit: 0 vulnerabilities.
- `mise run security` reports existing Python test-environment advisories: Home Assistant 2026.9.0b6 pins cryptography 48.0.1. No dependency requirements changed in this PR. The separate JavaScript audit passed after the Python audit stopped the combined task.
- No real Hevy account writes were exercised. Browser fixtures and Home Assistant tests use synthetic data.

## Checklist

- [x] Tests added for configuration, privacy persistence, completed-set editing, profile fallbacks, and account selection
- [x] Version and changelog updated together for 1.5.0
- [x] README and development instructions updated

Independent review and hosted checks are required before merge.
